### PR TITLE
Add build to firebase json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "public",
+    "public": "build",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
Deploy build directory instead of the public one. This will deploy the react app instead of a blank page